### PR TITLE
react: Add billboard.js

### DIFF
--- a/packages/chart-react-billboard.js/.eslintrc.js
+++ b/packages/chart-react-billboard.js/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: "../react/.eslintrc.js",
+};

--- a/packages/chart-react-billboard.js/package.json
+++ b/packages/chart-react-billboard.js/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@tony/cv-chart-react-billboard.js",
+  "license": "All rights reserved",
+  "private": true,
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "module": "src/index.ts",
+  "scripts": {
+    "start": "echo 'noop'",
+    "build": "echo 'noop'",
+    "test": "echo 'noop'",
+    "lint": "eslint . -c .eslintrc.js --ext .ts,.tsx",
+    "prettier": "prettier src webpack --write",
+    "format": "yarn run prettier",
+    "update": "yarn run ncu",
+    "ncu": "ncu",
+    "clean": "rm -rf dist/"
+  },
+  "devDependencies": {
+    "@types/node": "^14.14.21",
+    "@types/react": "^17.0.0",
+    "@types/react-dom": "^17.0.0",
+    "cross-env": "^7.0.3",
+    "eslint-plugin-react": "^7.22.0",
+    "prettier": "^2.2.1",
+    "typescript": "^4.1.3"
+  },
+  "peerDependencies": {
+    "@typescript-eslint/eslint-plugin": "^4.13.0",
+    "@typescript-eslint/parser": "^4.13.0",
+    "eslint": "^7.18.0",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-promise": "^4.2.1"
+  },
+  "dependencies": {
+    "@datorama/akita": "^6.0.0",
+    "billboard.js": "^2.1.4",
+    "@tony/cv-lib": "*",
+    "fast-deep-equal": "^3.1.3",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
+    "rxjs": "^6.6.3"
+  }
+}

--- a/packages/chart-react-billboard.js/package.json
+++ b/packages/chart-react-billboard.js/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@datorama/akita": "^6.0.0",
-    "billboard.js": "^2.1.4",
+    "billboard.js": "^2.2.0-next.5",
     "@tony/cv-lib": "*",
     "fast-deep-equal": "^3.1.3",
     "react": "^17.0.1",

--- a/packages/chart-react-billboard.js/src/charts.tsx
+++ b/packages/chart-react-billboard.js/src/charts.tsx
@@ -1,0 +1,124 @@
+import bb from "billboard.js";
+import React from "react";
+
+import type { Observable, Subscription } from "rxjs";
+
+import { billboardJSChartQuery as query } from "./hub";
+import { DonutChartProps, LineChartProps } from "./query";
+import equal from "fast-deep-equal";
+
+import "billboard.js/dist/billboard.css";
+
+// Todo consolidate this into common code somewhere
+export function onEmit<T>(
+  source$: Observable<T>,
+  nextFn: (value: T) => void
+): Subscription {
+  return source$.subscribe(nextFn, console.error);
+}
+
+// Same as onEmit
+export const useAsyncEffect = (
+  effect: React.EffectCallback | (() => Promise<void>),
+  dependencies?: unknown[]
+): void =>
+  React.useEffect(() => {
+    effect();
+    return () => void 0;
+  }, dependencies);
+
+export const Chart: React.FC<bb.ChartOptions> = ({ data, ...props }) => {
+  const ref = React.useRef<HTMLDivElement>(null);
+  const [chart, setChart] = React.useState<bb.Chart | null>(null);
+  React.useEffect(() => {
+    if (!chart) {
+      const newChart = bb.generate({ bindto: ref.current, data, ...props });
+      setChart(newChart);
+      return () => newChart.unload();
+    }
+  }, [props, data]);
+
+  React.useEffect(() => {
+    if (!chart || !data) {
+      return;
+    }
+    if (chart && chart?.load && data) {
+      // @ts-ignore Data structure mismatches: https://github.com/naver/billboard.js/issues/1848
+      chart.load(data);
+    }
+  }, [data]);
+  return <div ref={ref} />;
+};
+
+export const LanguagePieChart: React.FC<
+  // Partial<React.ComponentProps<typeof ResponsivePie>>
+  Partial<DonutChartProps>
+> = (props) => {
+  const [chartData, setChartData] = React.useState<DonutChartProps>();
+  useAsyncEffect(async () => {
+    if (!chartData) {
+      setChartData((await query.getDonutChart()) as DonutChartProps);
+    }
+    return void 0;
+  });
+
+  React.useEffect(() => void 0, [chartData]);
+  React.useEffect(() => {
+    const subscriptions: Subscription[] = [
+      onEmit<DonutChartProps>(query.subDonutChart$(), (newChart) => {
+        const isChanged = !equal(newChart, chartData);
+        console.log("pie published", newChart, chartData, { isChanged });
+
+        if (isChanged) {
+          setChartData(newChart);
+        }
+      }),
+    ];
+
+    return () => {
+      subscriptions.map((it) => it.unsubscribe());
+    };
+  }, []);
+
+  if (!chartData) {
+    return null;
+  }
+
+  return <Chart {...chartData} {...props} />;
+};
+
+export const ActivityLineChart: React.FC<Partial<bb.ChartOptions>> = (
+  props
+) => {
+  const [chartData, setChartData] = React.useState<LineChartProps>();
+  useAsyncEffect(async () => {
+    if (!chartData) {
+      setChartData((await query.getLineChart()) as LineChartProps);
+    }
+    return void 0;
+  });
+
+  React.useEffect(() => void 0, [chartData]);
+  React.useEffect(() => {
+    const subscriptions: Subscription[] = [
+      onEmit<LineChartProps>(query.subLineChart$(), (newChart) => {
+        const isChanged = !equal(newChart, chartData);
+        console.log("pie published", newChart, chartData, { isChanged });
+
+        if (isChanged) {
+          setChartData(newChart);
+        }
+      }),
+    ];
+
+    return () => {
+      subscriptions.map((it) => it.unsubscribe());
+    };
+  }, []);
+
+  if (!chartData) {
+    return null;
+  }
+
+  return <Chart {...chartData} {...props} />;
+};

--- a/packages/chart-react-billboard.js/src/hub.ts
+++ b/packages/chart-react-billboard.js/src/hub.ts
@@ -1,0 +1,20 @@
+import {
+  activitiesQuery,
+  activityTypesQuery,
+  cvStore,
+  query,
+  orgsQuery,
+  orgTypesQuery,
+  languagesQuery,
+} from "@tony/cv-lib/hub";
+import { BillboardJSChartQuery } from "./query";
+
+export const billboardJSChartQuery = new BillboardJSChartQuery(
+  cvStore,
+  query,
+  activitiesQuery,
+  activityTypesQuery,
+  languagesQuery,
+  orgsQuery,
+  orgTypesQuery
+);

--- a/packages/chart-react-billboard.js/src/query.ts
+++ b/packages/chart-react-billboard.js/src/query.ts
@@ -67,8 +67,8 @@ export class BillboardJSChartQuery extends CVQuery {
               }
             ),
             type: donut(),
-            color: (color, languageName) =>
-              languages.find((language) => language.id === languageName.id)?.ui
+            color: (color, data) =>
+              languages.find((language) => language.id === data.id)?.ui
                 ?.backgroundColor ?? color,
             labels: {
               // billboard.js doesn't accept callbacks here

--- a/packages/chart-react-billboard.js/src/query.ts
+++ b/packages/chart-react-billboard.js/src/query.ts
@@ -1,0 +1,138 @@
+import bb, { donut, line } from "billboard.js";
+import type { Observable } from "rxjs";
+
+import { combineQueries } from "@datorama/akita";
+import { map, take } from "rxjs/operators";
+
+import { CVQuery } from "@tony/cv-lib/search/query";
+import type {
+  OrgsQuery,
+  OrgTypesQuery,
+  LanguagesQuery,
+  ActivityTypesQuery,
+  ActivitiesQuery,
+} from "@tony/cv-lib/search/query";
+
+import { CVStore } from "@tony/cv-lib/search/store";
+
+export type DonutChartProps = bb.ChartOptions;
+export type LineChartProps = bb.ChartOptions;
+
+export interface Results {
+  // Charts
+  donutChart: DonutChartProps;
+  lineChart: LineChartProps;
+}
+
+export const DEFAULT_RESULTS: Results = {
+  // Charts
+  donutChart: { data: {} },
+  lineChart: { data: {} },
+};
+
+export class BillboardJSChartQuery extends CVQuery {
+  constructor(
+    protected store: CVStore,
+    protected cvQuery: CVQuery,
+    protected activitiesQuery: ActivitiesQuery,
+    protected activityTypesQuery: ActivityTypesQuery,
+    protected languagesQuery: LanguagesQuery,
+    protected orgsQuery: OrgsQuery,
+    protected orgTypesQuery: OrgTypesQuery
+  ) {
+    super(
+      store,
+      activitiesQuery,
+      activityTypesQuery,
+      languagesQuery,
+      orgsQuery,
+      orgTypesQuery
+    );
+  }
+
+  //
+  // Chart
+  //
+  subDonutChart$(): Observable<DonutChartProps> {
+    return combineQueries([
+      this.visibleLanguageCount$(),
+      this.visibleLanguages$(),
+    ]).pipe(
+      map(([languageCount, languages]) => {
+        return {
+          data: {
+            columns: Object.entries(languageCount).map(
+              ([languageName, count]) => {
+                return [languageName, count];
+              }
+            ),
+            type: donut(),
+            color: (color, languageName) =>
+              languages.find((language) => language.id === languageName.id)?.ui
+                ?.backgroundColor ?? color,
+            labels: {
+              // billboard.js doesn't accept callbacks here
+              // issue: https://github.com/naver/billboard.js/issues/1845
+              colors: languages.reduce((languageColorMap, language) => {
+                if (language) {
+                  if (!(language.id in languageColorMap)) {
+                    languageColorMap[language.id] = language.ui.color as string;
+                  }
+                }
+                return languageColorMap;
+              }, {} as { [key: string]: string }),
+            },
+          },
+          legend: {
+            show: false,
+          },
+          size: {
+            height: 300,
+            width: 300,
+          },
+        } as bb.ChartOptions;
+      })
+    );
+  }
+
+  // await $queries.CV.getDonutChart()
+  getDonutChart(): Promise<DonutChartProps> {
+    return this.subDonutChart$().pipe(take(1)).toPromise();
+  }
+
+  subLineChart$(): Observable<LineChartProps> {
+    return this.visibleActivityYearCount$().pipe(
+      map((activityCount) => {
+        return {
+          data: {
+            x: "x",
+            columns: [
+              [
+                "x",
+                ...Object.keys(activityCount).map((year) => `${year}-01-01`),
+              ],
+              ["activityCount", ...Object.values(activityCount)],
+            ],
+            type: line(),
+          },
+          axis: {
+            x: {
+              type: "timeseries",
+              tick: {
+                format: "%Y-%m-%d",
+              },
+            },
+          },
+          legend: {
+            show: false,
+          },
+        } as bb.ChartOptions;
+      })
+    );
+  }
+
+  // await $queries.CV.getLineChart()
+  getLineChart(): Promise<LineChartProps> {
+    return this.subLineChart$().pipe(take(1)).toPromise();
+  }
+}

--- a/packages/chart-react-billboard.js/tsconfig.json
+++ b/packages/chart-react-billboard.js/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../react/tsconfig.json",
+  "include": ["src/*"]
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -53,7 +53,6 @@
   },
   "dependencies": {
     "@tabler/icons": "^1.38.1",
-    "billboard.js": "^2.1.4",
     "fast-deep-equal": "^3.1.3",
     "html-webpack-plugin": "^4.5.1",
     "react": "^17.0.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "@tabler/icons": "^1.38.1",
+    "billboard.js": "^2.1.4",
     "fast-deep-equal": "^3.1.3",
     "html-webpack-plugin": "^4.5.1",
     "react": "^17.0.1",

--- a/packages/react/src/App.tsx
+++ b/packages/react/src/App.tsx
@@ -1,4 +1,3 @@
-import bb, { donut, line } from "billboard.js";
 import moment from "moment";
 import React from "react";
 import Select from "react-select";
@@ -41,11 +40,10 @@ import { onEmit, useAsyncEffect } from "./utils";
 import {
   LanguagePieChart,
   ActivityLineChart,
-} from "@tony/cv-chart-react-nivo/src/charts";
+} from "@tony/cv-chart-react-billboard.js/src/charts";
 import christmasTreeSvg from "@tony/cv-data/img/icons/christmas-tree.svg";
 import "@tony/cv-nav/components";
 
-import "billboard.js/dist/billboard.css";
 import "./style.scss";
 
 enum ActionType {
@@ -110,41 +108,6 @@ const AppContainer: React.FC = ({ children }) => {
 // export function isUndefined(value: any): value is undefined {
 //   return value === undefined;
 // }
-export const Chart: React.FC<bb.ChartOptions> = ({ data, ...props }) => {
-  //| Parameters<bb.Chart["load"]>
-  const ref = React.useRef<HTMLDivElement>(null);
-  const [chart, setChart] = React.useState<bb.Chart | null>(null);
-  // const data = props?.data ? props?.data : undefined;
-  // data.json = undefined;
-  // // if (isObject(data?.json) || isUndefined(data?.json)) {
-  // //   data.json = [] as bb.Data["json"];
-  // // }
-  React.useEffect(() => {
-    if (!chart) {
-      const newChart = bb.generate({ bindto: ref.current, data, ...props });
-      setChart(newChart);
-      return () => newChart.unload();
-    }
-  }, [props, data]);
-
-  React.useEffect(() => {
-    if (!chart || !data) {
-      return;
-    }
-    if (chart && chart?.load && data) {
-      // @ts-ignore Data structure mismatches: https://github.com/naver/billboard.js/issues/1848
-      chart.load(data);
-    }
-  }, [data]);
-
-  // React.useLayoutEffect(() => {
-  //   if (chart?.resize) {
-  //     chart.resize();
-  //   }
-  // });
-  //
-  return <div ref={ref} />;
-};
 
 const App: React.FC = () => {
   const [results, dispatch] = React.useReducer(reducer, DEFAULT_RESULTS);
@@ -220,71 +183,10 @@ const App: React.FC = () => {
             }`}
           >
             <div className="chartRow--donut">
-              {/* <LanguagePieChart /> */}
-              <Chart
-                data={{
-                  columns: Object.entries(results.languageCount).map(
-                    ([languageName, count]) => {
-                      return [languageName, count];
-                    }
-                  ),
-                  type: donut(),
-                  color: (color, languageName) =>
-                    languagesQuery.getEntity(languageName)?.ui
-                      ?.backgroundColor ?? color,
-                  labels: {
-                    // billboard.js doesn't accept callbacks here
-                    // issue: https://github.com/naver/billboard.js/issues/1845
-                    colors: languagesQuery
-                      .getAll()
-                      .reduce((languageColorMap, language) => {
-                        if (language) {
-                          if (!(language.id in languageColorMap)) {
-                            languageColorMap[language.id] = language.ui
-                              .color as string;
-                          }
-                        }
-                        return languageColorMap;
-                      }, {} as { [key: string]: string }),
-                  },
-                }}
-                legend={{
-                  show: false,
-                }}
-                size={{
-                  height: 300,
-                  width: 300,
-                }}
-              />
+              <LanguagePieChart />
             </div>
             <div className="chartRow--line">
-              {/* <ActivityLineChart /> */}
-              <Chart
-                data={{
-                  x: "x",
-                  columns: [
-                    [
-                      "x",
-                      ...Object.keys(activitiesYearCountMap).map(
-                        (year) => `${year}-01-01`
-                      ),
-                    ],
-                    ["activityCount", ...Object.values(activitiesYearCountMap)],
-                  ],
-                  type: line(),
-                }}
-                axis={{
-                  x: {
-                    type: "timeseries",
-                    tick: {
-                      format: "%Y-%m-%d",
-                    },
-                  },
-                }}
-                legend={{
-                  show: false,
-                }}
-              />
+              <ActivityLineChart />
             </div>
           </div>
 

--- a/packages/react/src/App.tsx
+++ b/packages/react/src/App.tsx
@@ -1,3 +1,5 @@
+import bb, { donut, line } from "billboard.js";
+import moment from "moment";
 import React from "react";
 import Select from "react-select";
 import type { Subscription } from "rxjs";
@@ -43,6 +45,7 @@ import {
 import christmasTreeSvg from "@tony/cv-data/img/icons/christmas-tree.svg";
 import "@tony/cv-nav/components";
 
+import "billboard.js/dist/billboard.css";
 import "./style.scss";
 
 enum ActionType {
@@ -98,6 +101,51 @@ const AppContainer: React.FC = ({ children }) => {
   );
 };
 
+// tks akita https://github.com/datorama/akita/blob/49b6391934ba1f5c6ca63eebcf4a118955c14f65/libs/akita/src/lib/isObject.ts
+// export function isObject(value: any) {
+//   const type = typeof value;
+//   return value != null && (type == "object" || type == "function");
+// }
+// // https://github.com/datorama/akita/blob/49b6391934ba1f5c6ca63eebcf4a118955c14f65/libs/akita/src/lib/isUndefined.ts
+// export function isUndefined(value: any): value is undefined {
+//   return value === undefined;
+// }
+export const Chart: React.FC<bb.ChartOptions> = ({ data, ...props }) => {
+  //| Parameters<bb.Chart["load"]>
+  const ref = React.useRef<HTMLDivElement>(null);
+  const [chart, setChart] = React.useState<bb.Chart | null>(null);
+  // const data = props?.data ? props?.data : undefined;
+  // data.json = undefined;
+  // // if (isObject(data?.json) || isUndefined(data?.json)) {
+  // //   data.json = [] as bb.Data["json"];
+  // // }
+  React.useEffect(() => {
+    if (!chart) {
+      const newChart = bb.generate({ bindto: ref.current, data, ...props });
+      setChart(newChart);
+      return () => newChart.unload();
+    }
+  }, [props, data]);
+
+  React.useEffect(() => {
+    if (!chart || !data) {
+      return;
+    }
+    if (chart && chart?.load && data) {
+      // @ts-ignore Data structure mismatches: https://github.com/naver/billboard.js/issues/1848
+      chart.load(data);
+    }
+  }, [data]);
+
+  // React.useLayoutEffect(() => {
+  //   if (chart?.resize) {
+  //     chart.resize();
+  //   }
+  // });
+  //
+  return <div ref={ref} />;
+};
+
 const App: React.FC = () => {
   const [results, dispatch] = React.useReducer(reducer, DEFAULT_RESULTS);
 
@@ -141,6 +189,23 @@ const App: React.FC = () => {
     };
   }, []);
 
+  const activitiesYearCountMap = results.activities.reduce(
+    (jsonData, activity) => {
+      if (activity.createdDate) {
+        const year = moment(activity.createdDate).get("year").toString();
+        if (year in jsonData) {
+          jsonData[year] += 1;
+        } else {
+          jsonData[year] = 1;
+        }
+      }
+      return jsonData;
+    },
+    {} as { [key: string]: number }
+  );
+
+  console.log("activitiesYearCountMap", activitiesYearCountMap);
+
   const resultsCount = results?.activities ? results.activities.length : 0;
 
   return (
@@ -155,10 +220,71 @@ const App: React.FC = () => {
             }`}
           >
             <div className="chartRow--donut">
-              <LanguagePieChart />
+              {/* <LanguagePieChart /> */}
+              <Chart
+                data={{
+                  columns: Object.entries(results.languageCount).map(
+                    ([languageName, count]) => {
+                      return [languageName, count];
+                    }
+                  ),
+                  type: donut(),
+                  color: (color, languageName) =>
+                    languagesQuery.getEntity(languageName)?.ui
+                      ?.backgroundColor ?? color,
+                  labels: {
+                    // billboard.js doesn't accept callbacks here
+                    // issue: https://github.com/naver/billboard.js/issues/1845
+                    colors: languagesQuery
+                      .getAll()
+                      .reduce((languageColorMap, language) => {
+                        if (language) {
+                          if (!(language.id in languageColorMap)) {
+                            languageColorMap[language.id] = language.ui
+                              .color as string;
+                          }
+                        }
+                        return languageColorMap;
+                      }, {} as { [key: string]: string }),
+                  },
+                }}
+                legend={{
+                  show: false,
+                }}
+                size={{
+                  height: 300,
+                  width: 300,
+                }}
+              />
             </div>
             <div className="chartRow--line">
-              <ActivityLineChart />
+              {/* <ActivityLineChart /> */}
+              <Chart
+                data={{
+                  x: "x",
+                  columns: [
+                    [
+                      "x",
+                      ...Object.keys(activitiesYearCountMap).map(
+                        (year) => `${year}-01-01`
+                      ),
+                    ],
+                    ["activityCount", ...Object.values(activitiesYearCountMap)],
+                  ],
+                  type: line(),
+                }}
+                axis={{
+                  x: {
+                    type: "timeseries",
+                    tick: {
+                      format: "%Y-%m-%d",
+                    },
+                  },
+                }}
+                legend={{
+                  show: false,
+                }}
+              />
             </div>
           </div>
 

--- a/packages/react/src/style.scss
+++ b/packages/react/src/style.scss
@@ -136,7 +136,6 @@ a {
 
   display: grid;
   grid-template-columns: 400px 1fr;
-  grid-template-rows: 400px;
   grid-auto-rows: 1fr;
   justify-items: stretch;
   align-items: stretch;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3648,10 +3648,10 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
-billboard.js@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/billboard.js/-/billboard.js-2.1.4.tgz#bbc115753b209ed4d37c58fd94d0b392515ebdd5"
-  integrity sha512-wYNZuBOwdyXj0qkcSmbzeAnjLzv7kbOO5LCOSbWHN897c2reG/yzryiuwwZZBWxNlXFoWy0PaSBHwFMd/kAEeQ==
+billboard.js@^2.2.0-next.5:
+  version "2.2.0-next.6"
+  resolved "https://registry.yarnpkg.com/billboard.js/-/billboard.js-2.2.0-next.6.tgz#779d05dfdee86ad997706c35455f49d76083f30e"
+  integrity sha512-j0W9mxlD2atdN3eZRCojVXOX/yN82WOxXXiNz+vidGK/q7l0JcIdLwZL0qVtoH4c9CpembcFik8Bn7FHtcfSqQ==
   dependencies:
     d3-axis "^1.0.12"
     d3-brush "^1.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3648,6 +3648,25 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
+billboard.js@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/billboard.js/-/billboard.js-2.1.4.tgz#bbc115753b209ed4d37c58fd94d0b392515ebdd5"
+  integrity sha512-wYNZuBOwdyXj0qkcSmbzeAnjLzv7kbOO5LCOSbWHN897c2reG/yzryiuwwZZBWxNlXFoWy0PaSBHwFMd/kAEeQ==
+  dependencies:
+    d3-axis "^1.0.12"
+    d3-brush "^1.1.6"
+    d3-color "^1.4.1"
+    d3-drag "^1.2.5"
+    d3-dsv "^1.2.0"
+    d3-ease "^1.0.7"
+    d3-interpolate "^1.4.0"
+    d3-scale "^2.2.2"
+    d3-selection "^1.4.2"
+    d3-shape "^1.3.7"
+    d3-time-format "^2.2.3"
+    d3-transition "^1.3.2"
+    d3-zoom "^1.8.3"
+
 binary-extensions@^1.0.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
@@ -4412,15 +4431,15 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@2, commander@^2.11.0, commander@^2.12.1, commander@^2.20.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 commander@6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.0.tgz#b990bfb8ac030aedc6d11bc04d1488ffef56db75"
   integrity sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==
-
-commander@^2.11.0, commander@^2.12.1, commander@^2.20.0:
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
-  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commander@^4.0.1, commander@^4.1.1:
   version "4.1.1"
@@ -5028,10 +5047,41 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
+d3-array@^1.2.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
+  integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
+
 d3-array@^2.3.0:
   version "2.9.1"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.9.1.tgz#f355cc72b46c8649b3f9212029e2d681cb5b9643"
   integrity sha512-Ob7RdOtkqsjx1NWyQHMFLtCSk6/aKTxDdC4ZIolX+O+mDD2RzrsYgAyc0WGAlfYFVELLSilS7w8BtE3PKM8bHg==
+
+d3-axis@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-1.0.12.tgz#cdf20ba210cfbb43795af33756886fb3638daac9"
+  integrity sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ==
+
+d3-brush@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-1.1.6.tgz#b0a22c7372cabec128bdddf9bddc058592f89e9b"
+  integrity sha512-7RW+w7HfMCPyZLifTz/UnJmI5kdkXtpCbombUSs8xniAyo0vIbrDzDwUJB6eJOgl9u5DQOt2TQlYumxzD1SvYA==
+  dependencies:
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-interpolate "1"
+    d3-selection "1"
+    d3-transition "1"
+
+d3-collection@1:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
+  integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
+
+d3-color@1, d3-color@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
+  integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
 
 "d3-color@1 - 2", d3-color@^2.0.0:
   version "2.0.0"
@@ -5045,20 +5095,54 @@ d3-delaunay@^5.1.1:
   dependencies:
     delaunator "4"
 
+d3-dispatch@1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.6.tgz#00d37bcee4dd8cd97729dd893a0ac29caaba5d58"
+  integrity sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==
+
+d3-drag@1, d3-drag@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-1.2.5.tgz#2537f451acd39d31406677b7dc77c82f7d988f70"
+  integrity sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==
+  dependencies:
+    d3-dispatch "1"
+    d3-selection "1"
+
+d3-dsv@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-1.2.0.tgz#9d5f75c3a5f8abd611f74d3f5847b0d4338b885c"
+  integrity sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==
+  dependencies:
+    commander "2"
+    iconv-lite "0.4"
+    rw "1"
+
+d3-ease@1, d3-ease@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.7.tgz#9a834890ef8b8ae8c558b2fe55bd57f5993b85e2"
+  integrity sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==
+
+d3-format@1, d3-format@^1.4.4:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.5.tgz#374f2ba1320e3717eb74a9356c67daee17a7edb4"
+  integrity sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==
+
 "d3-format@1 - 2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-2.0.0.tgz#a10bcc0f986c372b729ba447382413aabf5b0767"
   integrity sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==
 
-d3-format@^1.4.4:
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.5.tgz#374f2ba1320e3717eb74a9356c67daee17a7edb4"
-  integrity sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==
-
 d3-hierarchy@^1.1.8:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz#2f6bee24caaea43f8dc37545fa01628559647a83"
   integrity sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ==
+
+d3-interpolate@1, d3-interpolate@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.4.0.tgz#526e79e2d80daa383f9e0c1c1c7dcc0f0583e987"
+  integrity sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==
+  dependencies:
+    d3-color "1"
 
 "d3-interpolate@1 - 2", "d3-interpolate@1.2.0 - 2", d3-interpolate@^2.0.1:
   version "2.0.1"
@@ -5080,6 +5164,18 @@ d3-scale-chromatic@^2.0.0:
     d3-color "1 - 2"
     d3-interpolate "1 - 2"
 
+d3-scale@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-2.2.2.tgz#4e880e0b2745acaaddd3ede26a9e908a9e17b81f"
+  integrity sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==
+  dependencies:
+    d3-array "^1.2.0"
+    d3-collection "1"
+    d3-format "1"
+    d3-interpolate "1"
+    d3-time "1"
+    d3-time-format "2"
+
 d3-scale@^3.0.0:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-3.2.3.tgz#be380f57f1f61d4ff2e6cbb65a40593a51649cfd"
@@ -5091,12 +5187,24 @@ d3-scale@^3.0.0:
     d3-time "1 - 2"
     d3-time-format "2 - 3"
 
-d3-shape@^1.2.2, d3-shape@^1.3.5:
+d3-selection@1, d3-selection@^1.1.0, d3-selection@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.4.2.tgz#dcaa49522c0dbf32d6c1858afc26b6094555bc5c"
+  integrity sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==
+
+d3-shape@^1.2.2, d3-shape@^1.3.5, d3-shape@^1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
   integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
   dependencies:
     d3-path "1"
+
+d3-time-format@2, d3-time-format@^2.1.3, d3-time-format@^2.2.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.3.0.tgz#107bdc028667788a8924ba040faf1fbccd5a7850"
+  integrity sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==
+  dependencies:
+    d3-time "1"
 
 "d3-time-format@2 - 3":
   version "3.0.0"
@@ -5104,13 +5212,6 @@ d3-shape@^1.2.2, d3-shape@^1.3.5:
   integrity sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==
   dependencies:
     d3-time "1 - 2"
-
-d3-time-format@^2.1.3:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.3.0.tgz#107bdc028667788a8924ba040faf1fbccd5a7850"
-  integrity sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==
-  dependencies:
-    d3-time "1"
 
 d3-time@1, d3-time@^1.0.11:
   version "1.1.0"
@@ -5121,6 +5222,34 @@ d3-time@1, d3-time@^1.0.11:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-2.0.0.tgz#ad7c127d17c67bd57a4c61f3eaecb81108b1e0ab"
   integrity sha512-2mvhstTFcMvwStWd9Tj3e6CEqtOivtD8AUiHT8ido/xmzrI9ijrUUihZ6nHuf/vsScRBonagOdj0Vv+SEL5G3Q==
+
+d3-timer@1:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.10.tgz#dfe76b8a91748831b13b6d9c793ffbd508dd9de5"
+  integrity sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==
+
+d3-transition@1, d3-transition@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-1.3.2.tgz#a98ef2151be8d8600543434c1ca80140ae23b398"
+  integrity sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==
+  dependencies:
+    d3-color "1"
+    d3-dispatch "1"
+    d3-ease "1"
+    d3-interpolate "1"
+    d3-selection "^1.1.0"
+    d3-timer "1"
+
+d3-zoom@^1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-1.8.3.tgz#b6a3dbe738c7763121cd05b8a7795ffe17f4fc0a"
+  integrity sha512-VoLXTK4wvy1a0JpH2Il+F2CiOhVu7VRXWF5M/LroMIh3/zBAC3WAt7QoIvPibOavVo20hN6/37vwAsdBejLyKQ==
+  dependencies:
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-interpolate "1"
+    d3-selection "1"
+    d3-transition "1"
 
 d@1, d@^1.0.1:
   version "1.0.1"
@@ -7247,7 +7376,7 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24:
+iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -11245,6 +11374,11 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   integrity sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=
   dependencies:
     aproba "^1.1.1"
+
+rw@1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
+  integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
 
 rxjs@6.3.3:
   version "6.3.3"


### PR DESCRIPTION
Staging URL: https://cv-react-v2.git-pull.com/dev/branch/v2-billboard.js/

https://naver.github.io/billboard.js/demo/

https://github.com/naver/billboard.js/
![image](https://user-images.githubusercontent.com/26336/103468800-a6f17180-4d22-11eb-8771-2d137fa5ccd1.png)

Good stuff:
- TypeScript. Despite it being named billboard.js
- Lots of examples, and the examples have sandboxes
- Animations work

Missing:
- Incongruency in formatters / configurability (see issues)
- Incongruency in data structures (see issues)

Issues:
- https://github.com/naver/billboard.js/issues/1848 `json` data typing structure mismatch between constructor (`.generate()`) and `.load()`
- https://github.com/naver/billboard.js/issues/1845: label coloring via callback
- https://github.com/naver/billboard.js/issues/1847: fill colors ([sandbox](https://stackblitz.com/edit/chart-mouseover-tooltip-colors?file=index.ts))